### PR TITLE
Update version.xml

### DIFF
--- a/version.xml
+++ b/version.xml
@@ -1,8 +1,8 @@
-<addon name="feast" version="9.3.0">
+<package name="feast" version="9.3.0">
   <depends on="BEAST.base" atleast="2.7.0" atmost="2.7.9"/>
   <depends on="BEAST.app" atleast="2.7.0" atmost="2.7.9"/>
 
-  <addonapp class="feast.fileio.SequenceExtractor"
+  <packageapp class="feast.fileio.SequenceExtractor"
       description="SequenceExtractor"
       icon="feast/fileio/SequenceExtractorIcon.png"/>
 
@@ -69,4 +69,4 @@
     <provider classname="feast.popmodels.ShiftedPopulationModel"/>
     <provider classname="feast.popmodels.CompoundPopulationModel"/>
   </service>
-</addon>
+</package>


### PR DESCRIPTION
Replace `addon` with `package`. I noticed because the package manager GUI failed to find the main method of `feast.fileio.SequenceExtractor` (but then otherwise does not know how to handle the app, so this is not particularly important).